### PR TITLE
Replaced all mentions of Majoolr with Modular

### DIFF
--- a/ArrayUtilsLib/Array256Lib.sol
+++ b/ArrayUtilsLib/Array256Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array256 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array256 Library provides a few utility functions to work with
- * storage uint256[] types in place. Majoolr provides smart contract services
+ * storage uint256[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/ArrayUtilsLib/truffle/contracts/Array128Lib.sol
+++ b/ArrayUtilsLib/truffle/contracts/Array128Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array128 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  *  The Array128 Library provides a few utility functions to work with
- * storage uint128[] types in place. Majoolr provides smart contract services
+ * storage uint128[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/ArrayUtilsLib/truffle/contracts/Array16Lib.sol
+++ b/ArrayUtilsLib/truffle/contracts/Array16Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array16 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array16 Library provides a few utility functions to work with
- * storage uint16[] types in place. Majoolr provides smart contract services
+ * storage uint16[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/ArrayUtilsLib/truffle/contracts/Array256Lib.sol
+++ b/ArrayUtilsLib/truffle/contracts/Array256Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array256 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array256 Library provides a few utility functions to work with
- * storage uint256[] types in place. Majoolr provides smart contract services
+ * storage uint256[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: Modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/ArrayUtilsLib/truffle/contracts/Array32Lib.sol
+++ b/ArrayUtilsLib/truffle/contracts/Array32Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array32 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array32 Library provides a few utility functions to work with
- * storage uint32[] types in place. Majoolr provides smart contract services
+ * storage uint32[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/ArrayUtilsLib/truffle/contracts/Array64Lib.sol
+++ b/ArrayUtilsLib/truffle/contracts/Array64Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array64 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array64 Library provides a few utility functions to work with
- * storage uint64[] types in place. Majoolr provides smart contract services
+ * storage uint64[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: Modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/ArrayUtilsLib/truffle/contracts/Array8Lib.sol
+++ b/ArrayUtilsLib/truffle/contracts/Array8Lib.sol
@@ -2,21 +2,21 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Array8 Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array8 Library provides a few utility functions to work with
- * storage uint8[] types in place. Majoolr provides smart contract services
+ * storage uint8[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and
  * usability. We also educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/CrowdsaleLib/IICOLib/truffle/contracts/Array256Lib.sol
+++ b/CrowdsaleLib/IICOLib/truffle/contracts/Array256Lib.sol
@@ -5,12 +5,12 @@ pragma solidity ^0.4.18;
  * @author Modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Modular, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
  * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Array256 Library provides a few utility functions to work with
- * storage uint256[] types in place. Majoolr provides smart contract services
+ * storage uint256[] types in place. Modular provides smart contract services
  * and security reviews for contract deployments in addition to working on open
  * source projects in the Ethereum community. Our purpose is to test, document,
  * and deploy reusable code onto the blockchain and improve both security and

--- a/CrowdsaleLib/IICOLib/truffle/contracts/LinkedListLib.sol
+++ b/CrowdsaleLib/IICOLib/truffle/contracts/LinkedListLib.sol
@@ -2,22 +2,22 @@ pragma solidity ^0.4.18;
 
 /**
  * @title LinkedListLib
- * @author Majoolr.io
+ * @author Modular, Inc
  *
  * version 1.0.0
- * Copyright (c) 2017 Modular, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  * 
  * The LinkedListLib provides functionality for implementing data indexing using
  * a circlular linked list
  *
- * Majoolr provides smart contract services and security reviews for contract
+ * Modular provides smart contract services and security reviews for contract
  * deployments in addition to working on open source projects in the Ethereum
  * community. Our purpose is to test, document, and deploy reusable code onto the
  * blockchain and improve both security and usability. We also educate non-profits,
  * schools, and other community members about the application of blockchain
- * technology. For further information: majoolr.io
+ * technology. For further information: modular.network
  *
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS

--- a/CrowdsaleLib/IICOLib/truffle/contracts/TokenLib.sol
+++ b/CrowdsaleLib/IICOLib/truffle/contracts/TokenLib.sol
@@ -2,23 +2,23 @@ pragma solidity ^0.4.18;
 
 /**
  * @title TokenLib
- * @author Majoolr.io
+ * @author Modular, Inc
  *
  * version 1.2.1
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Token Library provides functionality to create a variety of ERC20 tokens.
- * See https://github.com/Majoolr/ethereum-contracts for an example of how to
+ * See https://github.com/Moduler-Network/ethereum-contracts for an example of how to
  * create a basic ERC20 token.
  *
- * Majoolr works on open source projects in the Ethereum community with the
+ * Modular works on open source projects in the Ethereum community with the
  * purpose of testing, documenting, and deploying reusable code onto the
- * blockchain to improve security and usability of smart contracts. Majoolr
+ * blockchain to improve security and usability of smart contracts. Modular
  * also strives to educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/LinkedListLib/LinkedListLib.sol
+++ b/LinkedListLib/LinkedListLib.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.4.18;
  * version 1.0.0
  * Copyright (c) 2017 Modular Inc.
  * The MIT License (MIT)
- * https://github.com/Modular-network/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  * 
  * The LinkedListLib provides functionality for implementing data indexing using
  * a circlular linked list

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Modular Libraries
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/Modular-Network/ethereum-libraries.svg?columns=all)](https://waffle.io/Modular-Network/ethereum-libraries)
 
 
-Modular Libraries is a group of packages built for use on blockchains utilizing the Ethereum Virtual Machine (EVM). All libraries are deployed and linkable in your smart contracts on both Rinkeby, Ropsten, and Ethereum Mainnet. [We also have an ethereum-contracts repository that currently holds ICO contracts](https://github.com/Majoolr/ethereum-contracts "Github link").  
+Modular Libraries is a group of packages built for use on blockchains utilizing the Ethereum Virtual Machine (EVM). All libraries are deployed and linkable in your smart contracts on both Rinkeby, Ropsten, and Ethereum Mainnet. [We also have an ethereum-contracts repository that currently holds ICO contracts](https://github.com/Modular-Network/ethereum-contracts "Github link").  
 
 Libraries and contracts are currently written in Solidity and Solidity Assembly. If you are not familiar with the workings of Ethereum, smart contracts, or Solidity [please educate yourself by clicking here before proceeding](https://solidity.readthedocs.io/en/develop/introduction-to-smart-contracts.html "Solidity link").
 
@@ -31,7 +31,7 @@ Libraries and contracts are currently written in Solidity and Solidity Assembly.
 
 ## About Us
 
-Modular is hitting the ground running in becoming a valuable partner in the Ethereum community. Our new website is going up shortly because we just went through an identity crisis. [To learn more about Modular on our old website, our mission, as well as contributing please click here](https://majoolr.io "Majoolr website").
+Modular is hitting the ground running in becoming a valuable partner in the Ethereum community. Our new website is going up shortly because we just went through an identity crisis. [To learn more about Modular on our website, our mission, as well as contributing please click here](https://modular.network "Modular website").
 
 ## Why Modular Libraries?
 
@@ -57,7 +57,7 @@ Feedback, bug reports, library submissions, collaborations, and contributions ar
 If you have feedback about our libraries or questions about our documentation, or find a bug in our code, please contact us as soon as possible at contact@majoolr.io or reach out to us on on Gitter or Discord channel.  Significant contributions will be rewarded.
 
 ### Collaborations
-As part of the global Ethereum/Blockchain community, we at Majoolr want to do our part in supporting fellow projects and enthusiasts in the community.  If you need an audit, advice, help building a secure ICO or Ethereum Dapp, or any other type of collaboration, please get in touch at contact@majoolr.io where we can discuss the collaboration. 
+As part of the global Ethereum/Blockchain community, we at Modular want to do our part in supporting fellow projects and enthusiasts in the community.  If you need an audit, advice, help building a secure ICO or Ethereum Dapp, or any other type of collaboration, please get in touch at contact@majoolr.io where we can discuss the collaboration. 
 
 ### Code Contributions
 If you see an issue in our repo or a piece of code in our Libraries you want to improve, please don't hesitate to dive in.  We welcome help in any form and are more than willing to offer our assistance to developers who want to contribute to documentation, code fixes, or even new libraries or functionality!  We ask that you follow a few guidelines when making changes to the repo:
@@ -71,7 +71,7 @@ If you see an issue in our repo or a piece of code in our Libraries you want to 
 
 ### Code Quality
 
-We strive to maintain high standards at Majoolr . To accomplish this, we have included unit tests and a coverage report tool. We are using the [solitidy-coverage](https://github.com/sc-forks/solidity-coverage) tool and [Codecov](https://codecov.io/gh/Majoolr/ethereum-libraries) to host our reports and analysis. Let's keep growing our coverage percentage as much as we can!
+We strive to maintain high standards at Modular. To accomplish this, we have included unit tests and a coverage report tool. We are using the [solitidy-coverage](https://github.com/sc-forks/solidity-coverage) tool and [Codecov](https://codecov.io/gh/Modular-Network/ethereum-libraries) to host our reports and analysis. Let's keep growing our coverage percentage as much as we can!
 
 ## Why Libraries?
 
@@ -105,4 +105,4 @@ Utilizing libraries has some of the following drawbacks:
 
 ## In Conclusion
 
-As always you should stay informed and determine what works best for you and your project. We look forward to working with everyone and we welcome anyone that wants to collaborate. [Please visit Majoolr.io](https://majoolr.io "Majoolr website") to see more information about us and opportunities.
+As always you should stay informed and determine what works best for you and your project. We look forward to working with everyone and we welcome anyone that wants to collaborate. [Please visit modular.network](https://modular.network"Modular website") to see more information about us and opportunities.

--- a/StringUtilsLib/StringUtilsLib.sol
+++ b/StringUtilsLib/StringUtilsLib.sol
@@ -19,16 +19,16 @@ pragma solidity ^0.4.18;
  * limitations under the License.
  *
  * This utility library was forked from https://github.com/Arachnid/solidity-stringutils
- * into the Majoolr ethereum-libraries repo at https://github.com/Majoolr/ethereum-libraries
+ * into the Modular ethereum-libraries repo at https://github.com/Modular-Network/ethereum-libraries
  * with permission. It has been updated to be more compatible with solidity 0.4.18
  * coding patterns.
  *
- * Majoolr provides smart contract services and security reviews for contract
+ * Modular provides smart contract services and security reviews for contract
  * deployments in addition to working on open source projects in the Ethereum
  * community. Our purpose is to test, document, and deploy reusable code onto the
  * blockchain and improve both security and usability. We also educate non-profits,
  * schools, and other community members about the application of blockchain
- * technology. For further information: majoolr.io
+ * technology. For further information: modular.network
  *
  * @dev Functionality in this library is largely implemented using an
  *      abstraction called a 'slice'. A slice represents a part of a string -

--- a/StringUtilsLib/truffle/contracts/StringUtilsLib.sol
+++ b/StringUtilsLib/truffle/contracts/StringUtilsLib.sol
@@ -19,16 +19,16 @@ pragma solidity ^0.4.18;
  * limitations under the License.
  *
  * This utility library was forked from https://github.com/Arachnid/solidity-stringutils
- * into the Majoolr ethereum-libraries repo at https://github.com/Majoolr/ethereum-libraries
+ * into the Modular ethereum-libraries repo at https://github.com/Modular-Network/ethereum-libraries
  * with permission. It has been updated to be more compatible with solidity 0.4.18
  * coding patterns.
  *
- * Majoolr provides smart contract services and security reviews for contract
+ * Modular provides smart contract services and security reviews for contract
  * deployments in addition to working on open source projects in the Ethereum
  * community. Our purpose is to test, document, and deploy reusable code onto the
  * blockchain and improve both security and usability. We also educate non-profits,
  * schools, and other community members about the application of blockchain
- * technology. For further information: majoolr.io
+ * technology. For further information: modular.network
  *
  * @dev Functionality in this library is largely implemented using an
  *      abstraction called a 'slice'. A slice represents a part of a string -

--- a/TokenLib/TokenLib.sol
+++ b/TokenLib/TokenLib.sol
@@ -2,23 +2,23 @@ pragma solidity ^0.4.18;
 
 /**
  * @title TokenLib
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.2.1
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Token Library provides functionality to create a variety of ERC20 tokens.
- * See https://github.com/Majoolr/ethereum-contracts for an example of how to
+ * See https://github.com/Modular-Network/ethereum-contracts for an example of how to
  * create a basic ERC20 token.
  *
- * Majoolr works on open source projects in the Ethereum community with the
+ * Modular works on open source projects in the Ethereum community with the
  * purpose of testing, documenting, and deploying reusable code onto the
- * blockchain to improve security and usability of smart contracts. Majoolr
+ * blockchain to improve security and usability of smart contracts. Modular
  * also strives to educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/TokenLib/truffle/contracts/BasicMathLib.sol
+++ b/TokenLib/truffle/contracts/BasicMathLib.sol
@@ -2,22 +2,22 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Basic Math Library
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.2.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Basic Math Library is inspired by the Safe Math library written by
  * OpenZeppelin at https://github.com/OpenZeppelin/zeppelin-solidity/ .
- * Majoolr provides smart contract services and security reviews for contract
+ * Modular provides smart contract services and security reviews for contract
  * deployments in addition to working on open source projects in the Ethereum
  * community. Our purpose is to test, document, and deploy reusable code onto the
  * blockchain and improve both security and usability. We also educate non-profits,
  * schools, and other community members about the application of blockchain
  * technology.
- * For further information: majoolr.io, openzeppelin.org
+ * For further information: modular.network, openzeppelin.org
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/TokenLib/truffle/contracts/TokenLib.sol
+++ b/TokenLib/truffle/contracts/TokenLib.sol
@@ -2,23 +2,23 @@ pragma solidity ^0.4.18;
 
 /**
  * @title TokenLib
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.2.1
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Token Library provides functionality to create a variety of ERC20 tokens.
- * See https://github.com/Majoolr/ethereum-contracts for an example of how to
+ * See https://github.com/Modular-Network/ethereum-contracts for an example of how to
  * create a basic ERC20 token.
  *
- * Majoolr works on open source projects in the Ethereum community with the
+ * Modular works on open source projects in the Ethereum community with the
  * purpose of testing, documenting, and deploying reusable code onto the
- * blockchain to improve security and usability of smart contracts. Majoolr
+ * blockchain to improve security and usability of smart contracts. Modular
  * also strives to educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/TokenLib/v1.0.0/TokenLib.sol
+++ b/TokenLib/v1.0.0/TokenLib.sol
@@ -2,23 +2,23 @@ pragma solidity ^0.4.15;
 
 /**
  * @title TokenLib
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.0.0
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Token Library provides functionality to create a variety of ERC20 tokens.
- * See https://github.com/Majoolr/ethereum-contracts for an example of how to
+ * See https://github.com/Modular-Network/ethereum-contracts for an example of how to
  * create a basic ERC20 token.
  *
- * Majoolr works on open source projects in the Ethereum community with the
+ * Modular works on open source projects in the Ethereum community with the
  * purpose of testing, documenting, and deploying reusable code onto the
- * blockchain to improve security and usability of smart contracts. Majoolr
+ * blockchain to improve security and usability of smart contracts. Modular
  * also strives to educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/VestingLib/truffle/contracts/BasicMathLib.sol
+++ b/VestingLib/truffle/contracts/BasicMathLib.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Basic Math Library
- * @author Modular, Inc
+ * @author Modular Inc, https://modular.network
  *
  * version 1.2.1
  * Copyright (c) 2017 Modular, Inc

--- a/VestingLib/truffle/contracts/TokenLib.sol
+++ b/VestingLib/truffle/contracts/TokenLib.sol
@@ -2,23 +2,23 @@ pragma solidity ^0.4.18;
 
 /**
  * @title TokenLib
- * @author Majoolr.io
+ * @author Modular Inc, https://modular.network
  *
  * version 1.2.1
- * Copyright (c) 2017 Majoolr, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
- * https://github.com/Majoolr/ethereum-libraries/blob/master/LICENSE
+ * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *
  * The Token Library provides functionality to create a variety of ERC20 tokens.
- * See https://github.com/Majoolr/ethereum-contracts for an example of how to
+ * See https://github.com/Modular-Network/ethereum-contracts for an example of how to
  * create a basic ERC20 token.
  *
- * Majoolr works on open source projects in the Ethereum community with the
+ * Modular works on open source projects in the Ethereum community with the
  * purpose of testing, documenting, and deploying reusable code onto the
- * blockchain to improve security and usability of smart contracts. Majoolr
+ * blockchain to improve security and usability of smart contracts. Modular
  * also strives to educate non-profits, schools, and other community members
  * about the application of blockchain technology.
- * For further information: majoolr.io
+ * For further information: modular.network
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/VestingLib/truffle/contracts/VestingLib.sol
+++ b/VestingLib/truffle/contracts/VestingLib.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.4.18;
 
 /**
  * @title VestingLib
- * @author Modular.network
+ * @author Modular Inc, https://modular.network
  *
  * version 1.0.1
- * Copyright (c) 2017 Modular, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
  * https://github.com/Modular-Network/ethereum-libraries/blob/master/LICENSE
  *

--- a/WalletLib/WalletAdminLib.sol
+++ b/WalletLib/WalletAdminLib.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.18;
 
 /**
  * @title Wallet Admin Library
- * @author Modular.network
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
  * Copyright (c) 2017 Modular, Inc

--- a/WalletLib/WalletGetterLib.sol
+++ b/WalletLib/WalletGetterLib.sol
@@ -2,10 +2,10 @@ pragma solidity 0.4.18;
 
 /**
  * @title Wallet Getter Library
- * @author Modular.network
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Modular, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
  * https://github.com/Modular-network/ethereum-libraries/blob/master/LICENSE
  *

--- a/WalletLib/WalletMainLib.sol
+++ b/WalletLib/WalletMainLib.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.4.18;
 
 /**
  * @title Wallet Main Library
- * @author Modular.network
+ * @author Modular Inc, https://modular.network
  *
  * version 1.1.0
- * Copyright (c) 2017 Modular, LLC
+ * Copyright (c) 2017 Modular, Inc
  * The MIT License (MIT)
  * https://github.com/Modular-network/ethereum-libraries/blob/master/LICENSE
  *


### PR DESCRIPTION
I've gone through and changed all instances of Majoolr to Modular. 

I've used the following standard:
- @author Modular Inc, https://modular.network
- Copyright (c) 2017 Modular, Inc
- https://github.com/Modular-Network/ethereum-contracts (for all github links)
- For further information: modular.network

I've left Majoolr in a few locations:
- In README.md, I left the emails as @majoolr.io
- In README.md, I left the gitter link to https://gitter.im/Majoolr/EthereumLibraries since the Modular-Network gitter currently 404s.