### PR TITLE
Fix bug with compare() returning 0 incorrectly

### DIFF
--- a/StringUtilsLib/truffle/contracts/StringUtilsLib.sol
+++ b/StringUtilsLib/truffle/contracts/StringUtilsLib.sol
@@ -241,7 +241,10 @@ library StringUtilsLib {
             }
             if (a != b) {
                 // Mask out irrelevant bytes and check again
-                uint mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
+                uint256 mask = uint256(-1);
+                if(shortest < 32) {
+                  mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
+                }
                 var diff = (a & mask) - (b & mask);
                 if (diff != 0)
                     return int(diff);

--- a/StringUtilsLib/truffle/test/TestStringUtilsLibOne.sol
+++ b/StringUtilsLib/truffle/test/TestStringUtilsLibOne.sol
@@ -169,6 +169,14 @@ contract TestStringUtilsLibOne {
 		res = tSliceOne.compare(tSliceTwo);
 
 		Assert.equal(res, 0, "Slim Shady");
+
+		tSliceOne = "Helloooooooooooooooooooooooooooooo".toSlice();
+		tSliceTwo = "Welloooooooooooooooooooooooooooooo".toSlice();
+		res = tSliceOne.compare(tSliceTwo);
+		oneIsBeforeTwo = res < 0;
+
+		Assert.isTrue(oneIsBeforeTwo, "Long strings that are simmilar are not the same. Hello... string is before Wello... string");
+
 	}
 
 	function testEquals() {


### PR DESCRIPTION
#### PROBLEM

A bug existed where strings that only differ in the first few bytes, and longer than 32 bytes were returning 0 as if their contents were equal.

```solidity
// EXAMPLE 
string str1 = "Helloooooooooooooooooooooooooooooo".toSlice();
string str2 = "Welloooooooooooooooooooooooooooooo".toSlice();
str1.compare(str2); // returns 0
```

Notice the first characters are different but the result is `0` which indicates the string contents are equal.

The expected value returned should be a negative integer.

#### SOLUTION
This PR implements [the fix](https://github.com/Arachnid/solidity-stringutils/commit/93a1b9434615e0c83d2719a1755045a6cb902673) and adds a test scenario to validate it.

#### NOTES

I was not able to get the full rest suite running for `StringUtilsLib` so the test scenario was ran independently of the framework so please consider this during your review.