### PR TITLE
Making sizeOf return value more explicit

### DIFF
--- a/LinkedListLib/LinkedListLib.sol
+++ b/LinkedListLib/LinkedListLib.sol
@@ -80,7 +80,8 @@ library LinkedListLib {
     
     /// @dev Returns the number of elements in the list
     /// @param self stored linked list from contract
-    function sizeOf(LinkedList storage self) internal view returns (uint256 numElements) {
+    function sizeOf(LinkedList storage self) internal view returns (uint256) {
+        uint256 numElements;
         bool exists;
         uint256 i;
         (exists,i) = getAdjacent(self, HEAD, NEXT);
@@ -88,7 +89,7 @@ library LinkedListLib {
             (exists,i) = getAdjacent(self, i, NEXT);
             numElements++;
         }
-        return;
+        return numElements;
     }
 
     /// @dev Returns the links of a node as a tuple


### PR DESCRIPTION
Seems odd to have a bare `return` when this method returns `numElements`.